### PR TITLE
The .gitignore file now conforms to the standard outlien in Godot docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,23 @@
 # Godot 4+ specific ignores
 .godot/
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# VS Code ignores
 .vs
 .vscode
+
+# other ignores
 .idea
-Exodus.sln.DotSettings.user
+PlayerControllerAdddon.sln.DotSettings.user


### PR DESCRIPTION
The added ignores are a requirement to be accept into the AssetLib

https://docs.godotengine.org/en/latest/community/asset_library/submitting_to_assetlib.html