### PR TITLE
gitattributes now ignores Examples by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 * text=auto eol=lf
 
 # Only include the addons folder when downloading from the Asset Library.
-/**        export-ignore
-/addons    !export-ignore
-/addons/** !export-ignore
+/**                export-ignore
+/addons            !export-ignore
+/addons/**         !export-ignore
+
+# ignore Examples by default as it is non-essential to using the addon
+/addons/Examples/  export-ignore

--- a/addons/player_controller/LICENSE
+++ b/addons/player_controller/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 PolarBears studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
* gitattributes now ignores the Examples folder by default
* LICENSE copied to addons/player_controller so it remains in player's project