### PR TITLE
Enhancement/exported input actions

### DIFF
--- a/addons/player_controller/Scripts/Mouse.cs
+++ b/addons/player_controller/Scripts/Mouse.cs
@@ -7,7 +7,12 @@ public partial class Mouse : Node3D
 {
     [Export(PropertyHint.Range, "0,0.1,0.001,or_greater")]
     public float Sensitivity { get; set; } = 0.004f;
-    
+
+    [Export]
+    public bool UseController { get; set; } = false;
+
+    private Vector2 controllerVector;
+
     private Node3D _head;
     private Camera3D _camera;
 
@@ -31,18 +36,51 @@ public partial class Mouse : Node3D
             return;
         }
         
-        if (@event is InputEventMouseMotion eventMouseMotion)
+        if (UseController)
         {
-            // Horizontal movement of head
-            float angleForHorizontalRotation = -eventMouseMotion.Relative.X * Sensitivity;
-            _head.RotateY(angleForHorizontalRotation);
+            if (@event is InputEventJoypadMotion eventJoypadMotion)
+            {
+                // Horizontal movement of head
+                const float SensitivityControllerFactor = 5.0f;
+                float controllerSensitivity = Sensitivity * SensitivityControllerFactor;
+                if (eventJoypadMotion.Axis == JoyAxis.RightX)
+                {
+                    controllerVector.X = -eventJoypadMotion.AxisValue * controllerSensitivity;
+                }
+                else if (eventJoypadMotion.Axis == JoyAxis.RightY)
+                {
+                    controllerVector.Y = -eventJoypadMotion.AxisValue * controllerSensitivity;
+                }
+            }
+        }
+        else
+        {
+            if (@event is InputEventMouseMotion eventMouseMotion)
+            {
+                // Horizontal movement of head
+                float angleForHorizontalRotation = -eventMouseMotion.Relative.X * Sensitivity;
+                _head.RotateY(angleForHorizontalRotation);
 
-            // Vertical movement of head
+                // Vertical movement of head
+                Vector3 currentCameraRotation = _camera.Rotation;
+                currentCameraRotation.X += Convert.ToSingle(-eventMouseMotion.Relative.Y * Sensitivity);
+                currentCameraRotation.X = Mathf.Clamp(currentCameraRotation.X, Mathf.DegToRad(-90f), Mathf.DegToRad(90f));
+
+                _camera.Rotation = currentCameraRotation;
+            }
+        }
+    }
+
+    public override void _PhysicsProcess(double delta)
+    {
+        if (UseController)
+        {
+            _head.RotateY(controllerVector.X);
             Vector3 currentCameraRotation = _camera.Rotation;
-            currentCameraRotation.X += Convert.ToSingle(-eventMouseMotion.Relative.Y * Sensitivity);
+            currentCameraRotation.X += Convert.ToSingle(controllerVector.Y);
             currentCameraRotation.X = Mathf.Clamp(currentCameraRotation.X, Mathf.DegToRad(-90f), Mathf.DegToRad(90f));
-
-            _camera.Rotation = currentCameraRotation;				
+            _camera.Rotation = currentCameraRotation;
         }
     }
 }
+

--- a/addons/player_controller/Scripts/PlayerController.cs
+++ b/addons/player_controller/Scripts/PlayerController.cs
@@ -57,11 +57,6 @@ public partial class PlayerController : CharacterBody3D
 
 	private bool _wasHeadPreviouslyTouchingCeiling = false;
 
-	// This supports the function IsPhysicalKeyJustPressed emulating the behavior
-	// of IsActionJustPressed by only catching the first press of a key, but not
-	// the hold of the key.
-	private Godot.Collections.Dictionary<Key, bool> _keyHeld;
-
 	public override void _Ready()
 	{
 		_currentSpeed = WalkSpeed;
@@ -346,18 +341,6 @@ public partial class PlayerController : CharacterBody3D
         StairsSystem.SlideCameraSmoothBackToOrigin(slideCameraParams);
     }
 
-    public override void _UnhandledInput(InputEvent inputEvent)
-    {
-    	if (inputEvent is InputEventKey keyEvent)
-    	{
-    		Key key = keyEvent.Keycode;
-    		if (_keyHeld.ContainsKey(key) && !keyEvent.Pressed)
-    		{
-    			_keyHeld[key] = false;
-    		}
-    	}
-    }
-
 	private bool IsHeadTouchingCeiling()
 	{
 		for (int i = 0; i < NumOfHeadCollisionDetectors; i++)
@@ -376,35 +359,12 @@ public partial class PlayerController : CharacterBody3D
         return IsOnFloor() || StairsSystem.WasSnappedToStairsLastFrame();
     }
 
-	private bool IsPhysicalKeyJustPressed(Key key)
-	{
-		if (_keyHeld.ContainsKey(key) && _keyHeld[key])
-		{
-			return false;
-		}
-		else
-		{
-			bool justPressed = Input.IsPhysicalKeyPressed(key);
-			_keyHeld[key] = justPressed;
-			return justPressed;
-		}
-	}
-
 	private bool IsInputPressed(string inputAction, Key fallbackKey)
 	{
 		bool inputActionSet = !string.IsNullOrEmpty(inputAction);
 		return (
 			inputActionSet && Input.IsActionPressed(inputAction) ||
 			!inputActionSet && Input.IsPhysicalKeyPressed(fallbackKey)
-		);
-	}
-
-	private bool IsInputJustPressed(string inputAction, Key fallbackKey)
-	{
-		bool inputActionSet = !string.IsNullOrEmpty(inputAction);
-		return (
-			inputActionSet && Input.IsActionJustPressed(inputAction) ||
-			!inputActionSet && IsPhysicalKeyJustPressed(fallbackKey)
 		);
 	}
 

--- a/project.godot
+++ b/project.godot
@@ -33,44 +33,39 @@ import/fbx/enabled=false
 
 [input]
 
-up={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+test_forward={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":-1.0,"script":null)
 ]
 }
-down={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+test_backward={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":1.0,"script":null)
 ]
 }
-left={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+test_left={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
 ]
 }
-right={
-"deadzone": 0.5,
-"events": [null, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+test_right={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
 ]
 }
-jump={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+test_jump={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
-sprint={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+test_crouch={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":2,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
-crouch={
-"deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194326,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
-]
-}
-fire={
-"deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+test_sprint={
+"deadzone": 0.2,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 


### PR DESCRIPTION
# Changes
* All input (excepting look) now operate in one of two modes:
   1. As a hard-coded key so that the Player can be drag and drop and work immediately 
   2. As an input action the player must set in the Player's exports under the "Input" category.
* Right analog stick look toggle added to Mouse.cs for controller support.
* test_* input actions added which will only be visible to developers of this Addon. It will not be imported into user projects.