### PR TITLE
fixed physics tick dependence of jump

### DIFF
--- a/addons/player_controller/Scripts/Gravity.cs
+++ b/addons/player_controller/Scripts/Gravity.cs
@@ -11,6 +11,8 @@ public partial class Gravity: Node3D
 	[Export(PropertyHint.Range, "0.01,10,0.01,or_greater")]
 	public float AdditionalGravityPower { get; set; } = 2f;
 
+	const float JumpFudgeFactor = 6.94e-3f;
+
 	private float _gravity;
 
 	public void Init(float gravitySetting)
@@ -18,6 +20,6 @@ public partial class Gravity: Node3D
 		_gravity = gravitySetting;
 	}
 
-	public float CalculateJumpForce() => Weight * (_gravity * (StartVelocity / AdditionalGravityPower));
+	public float CalculateJumpForce() => JumpFudgeFactor * Weight * (_gravity * (StartVelocity / AdditionalGravityPower));
 	public float CalculateGravityForce() => _gravity * Weight / 30.0f;
 }

--- a/addons/player_controller/Scripts/PlayerController.cs
+++ b/addons/player_controller/Scripts/PlayerController.cs
@@ -159,7 +159,7 @@ public partial class PlayerController : CharacterBody3D
 		{
 			Velocity = new Vector3(
 				x: Velocity.X,
-				y: Gravity.CalculateJumpForce() * (float)delta,
+				y: Gravity.CalculateJumpForce(),
 				z: Velocity.Z);
 			EmitSignal(SignalName.Jumped);
 		}

--- a/project.godot
+++ b/project.godot
@@ -69,10 +69,6 @@ test_sprint={
 ]
 }
 
-[physics]
-
-common/physics_ticks_per_second=144
-
 [rendering]
 
 anti_aliasing/quality/msaa_2d=3


### PR DESCRIPTION
Jump height is no longer dependent on the physics tick rate.

I assumed the problem was the opposite of what it actually turned out to be. It wasn't that jump calculations weren't being normalized with delta time, it's that they were when they should not be because they are only calculated for a single frame instead of a batch of frames. 

I removed the delta time normalization, but maintained the same jump strength with the same default parameters by multiplying by a fudge factor. I also simplified our project.godot by reducing the physics tick rate to the default 60 Hz. In general I think it is good to have as many default values in our project settings as possible so we target the most common project settings in other people's projects. 