### PR TITLE
adjustments/crouch-transition-speed-with-other-little-adjustments

### DIFF
--- a/addons/player_controller/Examples/MovementTestbed/MovementTestbed.tscn
+++ b/addons/player_controller/Examples/MovementTestbed/MovementTestbed.tscn
@@ -150,7 +150,6 @@ environment = SubResource("Environment_l208q")
 
 [node name="Player" parent="." instance=ExtResource("4_mphxi")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 1, 0)
-CrouchTransitionSpeed = 75.0
 
 [node name="Stairs" parent="." instance=ExtResource("7_1ct0v")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 21.066, 0.5, 19)

--- a/addons/player_controller/Examples/MovementTestbed/MovementTestbed.tscn
+++ b/addons/player_controller/Examples/MovementTestbed/MovementTestbed.tscn
@@ -91,7 +91,7 @@ size = Vector3(10, 2, 4)
 material = ExtResource("3_srqdk")
 
 [node name="Box2_5Meters" type="CSGBox3D" parent="Map"]
-transform = Transform3D(-1, 0, 1.50996e-07, 0, 1, 0, -1.50996e-07, 0, -1, 6, 1.75, -20.5)
+transform = Transform3D(-1, 0, 1.50996e-07, 0, 1, 0, -1.50996e-07, 0, -1, 5, 1.75, -20.5)
 use_collision = true
 size = Vector3(4, 2.5, 4)
 material = ExtResource("3_srqdk")
@@ -150,6 +150,7 @@ environment = SubResource("Environment_l208q")
 
 [node name="Player" parent="." instance=ExtResource("4_mphxi")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.5, 1, 0)
+CrouchTransitionSpeed = 75.0
 
 [node name="Stairs" parent="." instance=ExtResource("7_1ct0v")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 21.066, 0.5, 19)

--- a/addons/player_controller/Scripts/CapsuleCollider.cs
+++ b/addons/player_controller/Scripts/CapsuleCollider.cs
@@ -42,13 +42,13 @@ public partial class CapsuleCollider : CollisionShape3D
 
 	public void Crouch(float delta, float crouchTransitionSpeed)
 	{
-		float new_height = _shape.Height - delta * crouchTransitionSpeed;
-		_shape.Height = Mathf.Clamp(new_height, CapsuleCrouchHeight, CapsuleDefaultHeight);
+		float newHeight = _shape.Height - delta * crouchTransitionSpeed;
+		_shape.Height = Mathf.Clamp(newHeight, CapsuleCrouchHeight, CapsuleDefaultHeight);
 	}
 
 	public void UndoCrouching(float delta, float crouchTransitionSpeed)
 	{
-		float new_height = _shape.Height + delta * crouchTransitionSpeed;
-		_shape.Height = Mathf.Clamp(new_height, CapsuleCrouchHeight, CapsuleDefaultHeight);
+		float newHeight = _shape.Height + delta * crouchTransitionSpeed;
+		_shape.Height = Mathf.Clamp(newHeight, CapsuleCrouchHeight, CapsuleDefaultHeight);
 	}
 }

--- a/addons/player_controller/Scripts/PlayerController.cs
+++ b/addons/player_controller/Scripts/PlayerController.cs
@@ -26,8 +26,8 @@ public partial class PlayerController : CharacterBody3D
 	public float SprintSpeed           { get; set; } = 7.2f;
 	[Export(PropertyHint.Range, "0,10,0.1,or_greater")]
 	public float CrouchSpeed           { get; set; } = 2.5f;
-	[Export(PropertyHint.Range, "75,100,0.1,or_greater")]
-	public float CrouchTransitionSpeed { get; set; } = 20.0f;
+	
+	private float CrouchTransitionSpeed { get; set; } = 75.0f;
 
 	[ExportGroup("Input")]
 	[Export]

--- a/addons/player_controller/Scripts/PlayerController.cs
+++ b/addons/player_controller/Scripts/PlayerController.cs
@@ -26,7 +26,7 @@ public partial class PlayerController : CharacterBody3D
 	public float SprintSpeed           { get; set; } = 7.2f;
 	[Export(PropertyHint.Range, "0,10,0.1,or_greater")]
 	public float CrouchSpeed           { get; set; } = 2.5f;
-	[Export(PropertyHint.Range, "0,100,0.1,or_greater")]
+	[Export(PropertyHint.Range, "75,100,0.1,or_greater")]
 	public float CrouchTransitionSpeed { get; set; } = 20.0f;
 
 	[ExportGroup("Input")]


### PR DESCRIPTION
1. Adjust csg box on the Movement test bed, so player does not getting stuck in it
2. Adjust variables' naming in CapsuleCollider.cs
3. Make `CrouchTransitionSpeed` a private variable


## Motivation behind making `CrouchTransitionSpeed` a private variable:
1. With low values of the variable there are visual glitches [especially on the stairs]: 
[video](https://github.com/user-attachments/assets/c74865da-dd6b-44a0-9abc-8d21ff2e1275)

2. Low `CrouchTransitionSpeed` also creates visual glitches when going from standing mode to crouching mode and approaching some crouching holes
