### PR TITLE
Bugfix/jitter camera at ends of slow crouch transitions

### DIFF
--- a/addons/player_controller/Scripts/PlayerController.cs
+++ b/addons/player_controller/Scripts/PlayerController.cs
@@ -26,8 +26,8 @@ public partial class PlayerController : CharacterBody3D
 	public float SprintSpeed           { get; set; } = 7.2f;
 	[Export(PropertyHint.Range, "0,10,0.1,or_greater")]
 	public float CrouchSpeed           { get; set; } = 2.5f;
-	[Export(PropertyHint.Range, "0,100,0.1,or_greater")]
-	public float CrouchTransitionSpeed { get; set; } = 75.0f;
+	[Export(PropertyHint.Range, "25,100,0.1,or_greater")]
+	public float CrouchTransitionSpeed { get; set; } = 25.0f;
 
 	[ExportGroup("Input")]
 	[Export]

--- a/addons/player_controller/Scripts/PlayerController.cs
+++ b/addons/player_controller/Scripts/PlayerController.cs
@@ -26,8 +26,8 @@ public partial class PlayerController : CharacterBody3D
 	public float SprintSpeed           { get; set; } = 7.2f;
 	[Export(PropertyHint.Range, "0,10,0.1,or_greater")]
 	public float CrouchSpeed           { get; set; } = 2.5f;
-	
-	private float CrouchTransitionSpeed { get; set; } = 75.0f;
+	[Export(PropertyHint.Range, "0,100,0.1,or_greater")]
+	public float CrouchTransitionSpeed { get; set; } = 75.0f;
 
 	[ExportGroup("Input")]
 	[Export]

--- a/addons/player_controller/Scripts/StairsSystem.cs
+++ b/addons/player_controller/Scripts/StairsSystem.cs
@@ -330,8 +330,9 @@ public partial class StairsSystem: Node3D
 			positionForModification.Y = 0.05f;
 		}
 
-		positionForModification.Y = Mathf.Lerp(
-			_cameraSmooth.Position.Y, 0.0f,  _lerpingWeight  * parameters.Delta);
+		positionForModification.Y = Mathf.Clamp(
+			Mathf.Lerp(_cameraSmooth.Position.Y, 0.0f,  _lerpingWeight  * parameters.Delta),
+		_cameraSmooth.Position.Y, 0.0f);
 
 		_cameraSmooth.Position = positionForModification;
 

--- a/addons/player_controller/Scripts/StairsSystem.cs
+++ b/addons/player_controller/Scripts/StairsSystem.cs
@@ -331,9 +331,15 @@ public partial class StairsSystem: Node3D
 		}
 
 		// lerp is unbounded, the clamp avoids overshoots
-		positionForModification.Y = Mathf.Clamp(
-			Mathf.Lerp(_cameraSmooth.Position.Y, 0.0f,  _lerpingWeight  * parameters.Delta),
-		-MaxCameraDelayDistance, MaxCameraDelayDistance);
+		if (_cameraSmooth.Position.Y < 0.0f) {
+			positionForModification.Y = Mathf.Clamp(
+				Mathf.Lerp(_cameraSmooth.Position.Y, 0.0f,  _lerpingWeight  * parameters.Delta),
+			-MaxCameraDelayDistance, 0.0f);
+		} else {
+			positionForModification.Y = Mathf.Clamp(
+				Mathf.Lerp(_cameraSmooth.Position.Y, 0.0f,  -_lerpingWeight  * parameters.Delta),
+			0.0f, MaxCameraDelayDistance);
+		}
 
 		_cameraSmooth.Position = positionForModification;
 

--- a/addons/player_controller/Scripts/StairsSystem.cs
+++ b/addons/player_controller/Scripts/StairsSystem.cs
@@ -330,9 +330,10 @@ public partial class StairsSystem: Node3D
 			positionForModification.Y = 0.05f;
 		}
 
+		// lerp is unbounded, the clamp avoids overshoots
 		positionForModification.Y = Mathf.Clamp(
 			Mathf.Lerp(_cameraSmooth.Position.Y, 0.0f,  _lerpingWeight  * parameters.Delta),
-		_cameraSmooth.Position.Y, 0.0f);
+		-MaxCameraDelayDistance, MaxCameraDelayDistance);
 
 		_cameraSmooth.Position = positionForModification;
 


### PR DESCRIPTION
* Fixed camera jitter at ends of crouch movement when lower crouch speed is used.
* Exported crouch transition speed. 